### PR TITLE
인메모리 캐싱 구현

### DIFF
--- a/src/lib/data/cache/cache-fn.ts
+++ b/src/lib/data/cache/cache-fn.ts
@@ -1,0 +1,24 @@
+export const cacheNullaryFn = <R>(ttl: number, fn: () => R): (() => R) => {
+  let lastCalledTime = 0;
+  let cachedValue: R;
+  return (): R => {
+    const now = Date.now();
+    if (now < lastCalledTime + ttl * 1000) return cachedValue;
+    lastCalledTime = now;
+    cachedValue = fn();
+    return cachedValue;
+  };
+};
+
+export const cacheFn = <P extends Array<unknown>, R>(
+  ttl: number,
+  fn: (...p: P) => R,
+): ((...p: P) => R) => {
+  const cacheMap = new Map<string, () => R>();
+  return (...p: P): R => {
+    const key = JSON.stringify(p);
+    const cache = cacheMap.get(key) ?? cacheNullaryFn(ttl, () => fn(...p));
+    cacheMap.set(key, cache);
+    return cache();
+  };
+};


### PR DESCRIPTION
TTL을 기반으로 요청을 캐싱하는 유틸을 구현했습니다.

또한, 모든 spreadsheets 요청에 적용했습니다.